### PR TITLE
feat: Remove compass dependency

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ double motorPower;
 //0 = Defense
 int robot = 0;
 Process process(robot);
-CompassSensor compassSensor;
+// CompassSensor compassSensor;
 // Motor motor(0);
 // Switch switches;
 // Cam cam;
@@ -19,7 +19,7 @@ void setup()
   Serial2.begin(2000000);
   Serial7.begin(921600);
   // pinMode(6, OUTPUT);
-  compassSensor.calibrate(); 
+  // compassSensor.calibrate();
   // pinMode(21, OUTPUT);
   // pinMode(20, OUTPUT);
   // pinMode(3, OUTPUT);

--- a/src/motor.cpp
+++ b/src/motor.cpp
@@ -80,7 +80,7 @@ void Motor::Move(double intended_angle, double motor_power, double initialOrient
     powerFL = sin(toRadians(intended_angle - 305));
     // find max_power among motors to scale
     max_power = max(max(abs(powerFR), abs(powerFL)), max(abs(powerRR), abs(powerRL)));
-    FindCorrection(compassSensor.getOrientation(), initialOrientation);
+    FindCorrection(0, initialOrientation);
     // add correction to account for rotation needed
 
     powerFR = powerFR / max_power;
@@ -159,13 +159,13 @@ void Motor::Stop()
 double Motor::RecordDirection()
 {
 
-    initialOrientation = compassSensor.getOrientation();
+    initialOrientation = 0;
     return initialOrientation;
 }
 
 double Motor::getOrientation()
 {
-    return compassSensor.getOrientation();
+    return 0;
 }
 
 double Motor::FindCorrection(double orientation, double initialOrientation)
@@ -221,7 +221,7 @@ double Motor::FindCorrection(double orientation, double initialOrientation)
     }
     Serial.print("correction: ");
     Serial.println(correction);
-    return correction;
+    return 0;
 }
 void Motor::motorFL(double control, int speed){
     if (physicalRobot == 0){

--- a/src/motor.h
+++ b/src/motor.h
@@ -5,7 +5,7 @@
 #include <trig.h>
 #include <orbit.h>
 #include <switches.h>
-#include <compassSensor.h>
+// #include <compassSensor.h>
 #include <PID_v1.h>
 
 class Motor
@@ -20,7 +20,7 @@ public:
   double getOrientation();
   bool spin(int target);
   double speedControl(int ballDist, double initialSpee, int role);
-  CompassSensor compassSensor;
+  // CompassSensor compassSensor;
   int dirAngle;
   double correction;
   bool defenseStop;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8,11 +8,11 @@ Process::Process(int physicalRobot):roleSwitch(physicalRobot), motor(physicalRob
 void Process::general(int role)
 {
     Serial.println("beign general");
-    orientation = motor.getOrientation();
+    // orientation = motor.getOrientation();
     calbiration.calState(motor, lineDetection);
-    lineAngle = lineDetection.Process(calbiration.calVal, orientation, motor.initialOrientation);
+    lineAngle = lineDetection.Process(calbiration.calVal, 0, motor.initialOrientation);
     cam.CamCalc();
-    motor.FindCorrection(motor.getOrientation(), motor.initialOrientation);
+    motor.FindCorrection(0, motor.initialOrientation);
     if(role == 1){
         localization.offenseLocalization(motor.orientationVal, getAwayGoal(), getHomeGoal());
         motor.myPID.SetTunings(0.28, 0, 0.00005);
@@ -129,11 +129,11 @@ int Process::getOrientationOffense(double moveAngle)
 {
     if (switches.lightgate() || (cam.ballDistance <= 25 && ((moveAngle > 0 && moveAngle < 10) || (moveAngle > 350 && moveAngle < 360))))
     {
-        return goal.scoreOrientation(orientation, getAwayGoal(), motor.initialOrientation);
+        return goal.scoreOrientation(0, getAwayGoal(), motor.initialOrientation);
     }
     // int ballCheck = goal.ballAngleCheck(cam.ball, motor.initialOrientation, orientation);
     // if (cam.ballDistance < 60 && (ballCheck < 70 || ballCheck > 290))
     //     return goal.scoreOrientation(orientation, getAwayGoal(), motor.initialOrientation);
     else
-        return goal.scoreOrientation(orientation, getAwayGoal(), motor.correction);
+        return goal.scoreOrientation(0, getAwayGoal(), motor.correction);
 }


### PR DESCRIPTION
Removes the dependency on the compass sensor, which is not working. This allows the offense bot to function without the compass, although the robot's ability to move in a straight line may be affected.